### PR TITLE
Do not split code lines (really messed up with rtl languages)

### DIFF
--- a/src/css/_base.scss
+++ b/src/css/_base.scss
@@ -177,6 +177,7 @@ code {
 }
 
 code {
+    white-space: pre;
     padding: 1px 5px;
 }
 


### PR DESCRIPTION
Before: 

![image](https://user-images.githubusercontent.com/1955774/139527132-c61a525e-9921-4df7-8bd0-bcef12087520.png)


After:

![image](https://user-images.githubusercontent.com/1955774/139527112-812bdfb5-59bf-4379-b58d-6126bbe16aba.png)

The `‎--preferred-challenges=http` command was split, which for a Left to right language is not perfect but can be readable. But, included in a right-to-left sentence, makes it unintelligible.

The fix prevents all `<code>` (in Markdown, elements between `` `backtick` ``) to split the text inside it. I've checked others pages impacted, and it does improve them. The main notable change is in the CP:

Before:

![image](https://user-images.githubusercontent.com/1955774/139527312-a537665a-5e96-451f-abb7-f2786678809c.png)

After:

![image](https://user-images.githubusercontent.com/1955774/139527298-feca5342-fcc0-4765-b338-d77aeb9d0d3d.png)



